### PR TITLE
fix for single-element float arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function cleanYamlObj(object, filter, isRoot, seen) {
 		// Fill in any holes.  This means we lose expandos,
 		// but we were gonna lose those anyway.
 		if (isArray) {
-			object = Array.apply(null, object);
+			object = fillHoles(object);
 		}
 
 		var isError = object && typeof object === 'object' && object instanceof Error;
@@ -79,3 +79,12 @@ function setProp(propName, source, target, seen, filter) {
 function defaultFilter() {
 	return true;
 }
+
+function fillHoles(arr) {
+	var result = [];
+	for (var i = 0; i < arr.length; i++) {
+		result[i] = arr[i];
+	}
+	return result;
+}
+

--- a/test.js
+++ b/test.js
@@ -32,6 +32,11 @@ test('Array holes are filled', t => {
 	t.same(fn(array), ['a', null, null, null, 'c']);
 });
 
+test('Arrays with a single float are safe', t => {
+	const array = [1.5];
+	t.same(fn(array), [1.5]);
+});
+
 test.cb('Errors have their domain stripped', t => {
 	t.plan(2);
 


### PR DESCRIPTION
I have an ava test that deep-compares two objects. They had a difference in an array subelement containing floating point numbers. This was throwing an InvalidRange error, which was getting swallowed by ava until my test timed out, and it really threw me down a rabbit hole for an hour or so. Hopefully this saves someone else the same headache.

Fixes #7 
